### PR TITLE
[Feature] - Add ProcessInfo to Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ A one-stop shop for working with environment values in a Swift program.
 
 ```swift
 .package(url: "https://github.com/thebarndog/swift-dotenv.git", .upToNextMajor("1.0.0"))
-
-import SwiftDotenv
 ```
 
 ## Usage
+
+```swift
+import SwiftDotenv
+```
 
 ### `Environment`
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # SwiftDotenv
 
-A Swift micro-framework for loading and using `.env` files in a Swift framework or application.
+A one-stop shop for working with environment values in a Swift program. 
 
 ## Overview
 
-`SwiftDotenv` is a small and compact Swift package that allows you to load and save `.env` files at runtime.
+`SwiftDotenv` is a small and compact Swift package that allows you to load and save `.env` files at runtime and query for those values as well as system provided environemntal values via `ProcessInfo`. It's a single abstraction for dealing with environment variables at runtime as well as a handy mechanism keeping your secrets and private keys safe in a local configuration file that doesn't get committed to version control, rather than hardcoding secret strings into your app or framework.
 
 ### What is a `.env` file?
 
@@ -66,6 +66,18 @@ Enviroments that were created programmatically can also be saved to disk via `Do
 let environment = try Environment(values: ["API_KEY": "some-key"])
 try Dotenv.save(environment, atPath: ".env", force: false) // wont overwrite an existing file when force == false
 ```
+
+### `ProcessInfo` & `FallbackStrategy`
+
+If a value doesn't exist in the set of values fetched from your `.env` file, `Environment` will then fallback and look in `ProcessInfo` for the desired value. Custom fallback strategies can be also be set so that `Environment` will query first from `ProcessInfo` and then to the environment values pulled from the configuration file. 
+
+The default fallback strategy is `.init(query: .configuration, fallback: .process)` meaning `Environment` will first look for the value in the configuration file and then fallback to `ProcessInfo` if it can't find it. The `fallback` parameter can also be `nil`, removing fallback functionality. 
+
+To modify the fallback strategy:
+
+```swift
+Environment.fallbackStrategy = .init(query: .process)
+```  
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ let environment = try Environment(values: ["API_KEY": "some-key"])
 try Dotenv.save(environment, atPath: ".env", force: false) // wont overwrite an existing file when force == false
 ```
 
+By default, `Dotenv` uses `FileManger.default` to load and save files but even that can be swapped out:
+
+```swift
+Dotenv.fileManger = someCustomInstance
+```
+
 ### `ProcessInfo` & `FallbackStrategy`
 
 If a value doesn't exist in the set of values fetched from your `.env` file, `Environment` will then fallback and look in `ProcessInfo` for the desired value. Custom fallback strategies can be also be set so that `Environment` will query first from `ProcessInfo` and then to the environment values pulled from the configuration file. 

--- a/Sources/Dotenv.swift
+++ b/Sources/Dotenv.swift
@@ -9,6 +9,8 @@ import Foundation
 
 /// Structure used to load and save environment files.
 public struct Dotenv {
+
+    // MARK: - Types
     
     /// Failures that can occur during loading an environment.
     public enum LoadingFailure: Error {
@@ -23,13 +25,20 @@ public struct Dotenv {
         /// A configuration file already exists at that path.
         case fileAlreadyExists(path: String)
     }
+
+    // MARK: - Configuration
+
+    /// `FileManager` instance used to load and save configuration files. Can be replaced with a custom instance.
+    public static var fileManager = FileManager.default
+
+    // MARK: - Loading & Saving
     
     /// Load an environment file.
     /// - Parameter path: Path to load from, defaults to `.env`.
     /// - Returns: Environment object.
     /// - Throws: Any error that occurs during loading.
     public static func load(path: String = ".env") throws -> Environment {
-        let fileManager = FileManager.default
+        let fileManager = Self.fileManager
         guard fileManager.fileExists(atPath: path) else {
             throw LoadingFailure.environmentFileIsMissing
         }
@@ -47,7 +56,7 @@ public struct Dotenv {
     /// - Throws: Any error that occurs during saving such as a file already existing in the specified path.
     public static func save(environment: Environment, toPath path: String, force: Bool = false) throws {
         let contents = try environment.serialize()
-        let fileManager = FileManager.default
+        let fileManager = Self.fileManager
         guard !fileManager.fileExists(atPath: path) || force else {
             throw SavingFailure.fileAlreadyExists(path: path)
         }

--- a/Sources/Dotenv.swift
+++ b/Sources/Dotenv.swift
@@ -20,6 +20,7 @@ public struct Dotenv {
     
     /// Failures that can occur when saving an environment to disk.
     public enum SavingFailure: Error {
+        /// A configuration file already exists at that path.
         case fileAlreadyExists(path: String)
     }
     

--- a/Sources/Environment.swift
+++ b/Sources/Environment.swift
@@ -6,6 +6,7 @@
 //
 
 import Collections
+import Foundation
 
 /// Environment object that represents a `.env` configuration file.
 @dynamicMemberLookup
@@ -163,7 +164,7 @@ public struct Environment {
     // MARK: - Subscript
     
     public subscript(key: String) -> Value? {
-        values[key]
+        extractValue(forKey: key)
     }
     
     public subscript(key: String, default defaultValue: @autoclosure () -> Value) -> Value {
@@ -173,6 +174,16 @@ public struct Environment {
     // MARK: Dynamic Member Lookup
     
     public subscript(dynamicMember member: String) -> Value? {
-        values[member]
+        extractValue(forKey: member)
+    }
+    
+    // MARK: - Helpers
+    
+    private func extractValue(forKey key: String) -> Value? {
+        if let value = values[key] {
+            return value
+        }
+        // otherwise fallback to use `ProcessInfo`
+        return Value(ProcessInfo.processInfo.environment[key] ?? "")
     }
 }

--- a/Sources/Environment.swift
+++ b/Sources/Environment.swift
@@ -193,7 +193,7 @@ public struct Environment {
     
     /// Transform the environment into a string representation that can be written to disk.
     /// - Returns: File contents.
-    func serialize(includeProcess: Bool = false) throws -> String {
+    func serialize() throws -> String {
         values.enumerated().reduce(into: "") { accumulated, current in
             accumulated += "\(current.element.key)\(Self.delimeter)\(current.element.value.stringValue)\n"
         }


### PR DESCRIPTION
### Overview

The main source of environment variables in an iOS app is `ProcessInfo` and it's possible values will be loaded into the environment outside of the .env file. `SwiftDotenv` should fallback to use the system environmental values if the value isn't found in the environment object, as well as being able to determine precedence between which data source to query first. 