### PR TITLE
[Feature] - Adding and Removing Values

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections.git",
         "state": {
           "branch": null,
-          "revision": "2d33a0ea89c961dcb2b3da2157963d9c0370347e",
-          "version": "1.0.1"
+          "revision": "48254824bb4248676bf7ce56014ff57b142b77eb",
+          "version": "1.0.2"
         }
       }
     ]

--- a/Sources/Dotenv.swift
+++ b/Sources/Dotenv.swift
@@ -49,6 +49,7 @@ public struct Dotenv {
     }
     
     /// Save an environment object to a file.
+    /// - Important: This method does not serialize process values to disk.
     /// - Parameters:
     ///   - environment: Environment to serialize.
     ///   - path: Path to save the environment to.

--- a/Sources/Environment.swift
+++ b/Sources/Environment.swift
@@ -163,6 +163,12 @@ public struct Environment {
             }
         self.processInfo = processInfo
     }
+
+    /// Create an empty environment.
+    /// - Parameter processInfo: Process info to seed the environment with.
+    public init(processInfo: ProcessInfo = ProcessInfo.processInfo) throws {
+        try self.init(values: [:] as OrderedDictionary<String, Value>, processInfo: processInfo)
+    }
     
     /// Create an environment from the contents of a file.
     /// - Parameter contents: File contents.
@@ -197,11 +203,21 @@ public struct Environment {
     ///   - key: Key to set value for.
     ///   - force: Flag that indicates if the value should be forced if a value with the same key exists, defaults to `false`.
     /// - Important: If the environment is set to read from the process, this method is a no-op as the process' environment is read-only.
-    public mutating func setValue(_ value: Value?, forKey key :String, force: Bool = false) {
+    public mutating func setValue(_ value: Value?, forKey key: String, force: Bool = false) {
         guard values[key] == nil || force else {
             return
         }
         values[key] = value
+    }
+
+    /// Set a new value in the environment for the given key, optionally specifiying if the value should overwrite an existing value, if any exists.
+    /// - Parameters:
+    ///   - value: Value to set in the environment.
+    ///   - key: Key to set value for.
+    ///   - force: Flag that indicates if the value should be forced if a value with the same key exists, defaults to `false`.
+    /// - Important: If the environment is set to read from the process, this method is a no-op as the process' environment is read-only.
+    public mutating func setValue(_ value: String, forKey key: String, force: Bool = false) {
+        setValue(Value(value), forKey: key, force: force)
     }
 
     /// Remove a value for the given key, returning the old value, if any exsts.
@@ -210,7 +226,7 @@ public struct Environment {
     @discardableResult
     public mutating func removeValue(forKey key: String) -> Value? {
         let oldValue = queryValue(forKey: key)
-        setValue(nil, forKey: key)
+        setValue(nil, forKey: key, force: true)
         return oldValue
     }
     

--- a/Tests/EnvironmentTests.swift
+++ b/Tests/EnvironmentTests.swift
@@ -39,4 +39,64 @@ final class EnvironmentTests: XCTestCase {
         XCTAssertEqual(env.networkRetries, .integer(3))
         XCTAssertEqual(env.networkTimeout, .double(10.5))
     }
+
+    // MARK: - Adding and Removing Values
+
+    func testAddingValueForNonexistantKey() throws {
+        var environment = try Environment()
+
+        XCTAssertNil(environment.key)
+
+        environment.setValue(.integer(1), forKey: "key")
+
+        XCTAssertEqual(environment.key, .integer(1))
+    }
+
+    func testAddingValueForExistingKeyWithoutForcing() throws {
+        var environment = try Environment(values: [
+            "key": .integer(1)
+        ])
+
+        XCTAssertEqual(environment.key, .integer(1))
+
+        environment.setValue(.integer(2), forKey: "key")
+
+        XCTAssertEqual(environment.key, .integer(1))
+    }
+
+    func testAddingValueForExistingValueWithForcing() throws {
+        var environment = try Environment(values: [
+            "key": .integer(1)
+        ])
+
+        XCTAssertEqual(environment.key, .integer(1))
+
+        environment.setValue(.integer(2), forKey: "key", force: true)
+
+        XCTAssertEqual(environment.key, .integer(2))
+    }
+
+    func testRemovingNonexistantValue() throws {
+        var environment = try Environment()
+
+        XCTAssertNil(environment.key)
+
+        let oldValue = environment.removeValue(forKey: "key")
+
+        XCTAssertNil(oldValue)
+    }
+
+
+    func testRemovingValue() throws {
+        var environment = try Environment(values: [
+            "key": .integer(1)
+        ])
+
+        XCTAssertNotNil(environment.key)
+
+        let oldValue = environment.removeValue(forKey: "key")
+
+        XCTAssertEqual(oldValue, .integer(1))
+        XCTAssertNil(environment.key)
+    }
 }


### PR DESCRIPTION
### Context

This PR adds support for manipulating loaded environments at runtime. This is particular useful for things like incrementing the build version where the build version is stored in a `.env` file but it needs to be read and then re-serialized back to disk with the incremented value.

### Added

- `addValue(_:key:force:)`
- `removeValue(key:)`
- Tests 