### PR TITLE
[Feature] - CamelCase dynamic subscripting

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ let key = environment.apiKey // "some-key"
 let enabled = environment.onboardingEnabled // false
 ```
 
-**Note**: Keys that use snake case or dashes will not work with dynamic member lookup as the special characters aren't easily translated to property names.
-
 ### `Dotenv`
 
 To load an environment from a `.env` file, use `Dotenv.load(path:)`:

--- a/Sources/Environment.swift
+++ b/Sources/Environment.swift
@@ -153,6 +153,8 @@ public struct Environment {
     public init(values: OrderedDictionary<String, Value>, processInfo: ProcessInfo = ProcessInfo.processInfo) throws {
         self.values = try values
             .filter {
+                // have to check the string case and make sure that the key and value pair are not empty
+                // only needs to be checked for strings which unlike booleans, doubles, and integers, can be empty
                 guard case let .string(value) = $0.value else {
                     return true
                 }
@@ -161,6 +163,7 @@ public struct Environment {
                 }
                 return true
             }
+
         self.processInfo = processInfo
     }
 
@@ -263,9 +266,9 @@ public struct Environment {
     
     public subscript(dynamicMember member: String) -> Value? {
         get {
-            queryValue(forKey: member)
+            queryValue(forKey: member.camelCaseToSnakeCase().uppercased())
         } set {
-            setValue(newValue, forKey: member)
+            setValue(newValue, forKey: member.camelCaseToSnakeCase().uppercased())
         }
     }
     

--- a/Sources/String+CamelCase.swift
+++ b/Sources/String+CamelCase.swift
@@ -1,0 +1,64 @@
+//
+//  String+CamelCase.swift
+//  SwiftDotenv
+//
+//  Created by Brendan Conron on 5/6/22.
+//
+
+import Foundation
+
+extension String {
+
+    /// Convert a string from camel case to snake case.
+    /// Taken from
+    /// - Returns: https://github.com/apple/swift/blob/88b093e9d77d6201935a2c2fb13f27d961836777/stdlib/public/Darwin/Foundation/JSONEncoder.swift#L161
+    func camelCaseToSnakeCase() -> String {
+        guard !isEmpty else { return self }
+
+        var words: [Range<String.Index>] = []
+        // The general idea of this algorithm is to split words on transition from lower to upper case, then on transition of >1 upper case characters to lowercase
+        //
+        // myProperty -> my_property
+        // myURLProperty -> my_url_property
+        //
+        // We assume, per Swift naming conventions, that the first character of the key is lowercase.
+        var wordStart = startIndex
+        var searchRange = index(after: wordStart) ..< endIndex
+
+        // Find next uppercase character
+        while let upperCaseRange = rangeOfCharacter(from: CharacterSet.uppercaseLetters, options: [], range: searchRange) {
+            let untilUpperCase = wordStart ..< upperCaseRange.lowerBound
+            words.append(untilUpperCase)
+
+            // Find next lowercase character
+            searchRange = upperCaseRange.lowerBound ..< searchRange.upperBound
+            guard let lowerCaseRange = rangeOfCharacter(from: CharacterSet.lowercaseLetters, options: [], range: searchRange)
+            else {
+                // There are no more lower case letters. Just end here.
+                wordStart = searchRange.lowerBound
+                break
+            }
+
+            // Is the next lowercase letter more than 1 after the uppercase? If so, we encountered a group of uppercase letters that we should treat as its own word
+            let nextCharacterAfterCapital = index(after: upperCaseRange.lowerBound)
+            if lowerCaseRange.lowerBound == nextCharacterAfterCapital {
+                // The next character after capital is a lower case character and therefore not a word boundary.
+                // Continue searching for the next upper case for the boundary.
+                wordStart = upperCaseRange.lowerBound
+            } else {
+                // There was a range of >1 capital letters. Turn those into a word, stopping at the capital before the lower case character.
+                let beforeLowerIndex = index(before: lowerCaseRange.lowerBound)
+                words.append(upperCaseRange.lowerBound ..< beforeLowerIndex)
+
+                // Next word starts at the capital before the lowercase we just found
+                wordStart = beforeLowerIndex
+            }
+            searchRange = lowerCaseRange.upperBound ..< searchRange.upperBound
+        }
+        words.append(wordStart ..< searchRange.upperBound)
+        let result = words.map { range in
+            self[range].lowercased()
+        }.joined(separator: "_")
+        return result
+    }
+}

--- a/Sources/String+CamelCase.swift
+++ b/Sources/String+CamelCase.swift
@@ -10,8 +10,8 @@ import Foundation
 extension String {
 
     /// Convert a string from camel case to snake case.
-    /// Taken from
-    /// - Returns: https://github.com/apple/swift/blob/88b093e9d77d6201935a2c2fb13f27d961836777/stdlib/public/Darwin/Foundation/JSONEncoder.swift#L161
+    /// Taken from https://github.com/apple/swift/blob/88b093e9d77d6201935a2c2fb13f27d961836777/stdlib/public/Darwin/Foundation/JSONEncoder.swift#L161
+    /// - Returns: Snake case formatted string.
     func camelCaseToSnakeCase() -> String {
         guard !isEmpty else { return self }
 

--- a/Tests/DotenvTests.swift
+++ b/Tests/DotenvTests.swift
@@ -33,8 +33,9 @@ final class DotenvTests: XCTestCase {
             return
         }
         let env = try Dotenv.load(path: path)
-        XCTAssertEqual(env.key1, .string("value1"))
-        XCTAssertEqual(env.key2, .string("value2"))
+        print(env.values)
+        XCTAssertEqual(env.apiKey, .string("some-value"))
+        XCTAssertEqual(env.buildNumber, .integer(5))
         XCTAssertNil(env.nonExistentValue)
     }
     

--- a/Tests/EnvironmentTests.swift
+++ b/Tests/EnvironmentTests.swift
@@ -27,10 +27,10 @@ final class EnvironmentTests: XCTestCase {
     
     func testCreatingEnvironmentFromTypeSafeConstruct() throws {
         let env = try Environment(values: [
-            "apiKey": .string("some-secret"),
-            "onboardingEnabled": .boolean(true),
-            "networkRetries": .integer(3),
-            "networkTimeout": .double(10.5)
+            "API_KEY": .string("some-secret"),
+            "ONBOARDING_ENABLED": .boolean(true),
+            "NETWORK_RETRIES": .integer(3),
+            "NETWORK_TIMEOUT": .double(10.5)
         ])
         
         // implicitly testing subscripting
@@ -47,31 +47,32 @@ final class EnvironmentTests: XCTestCase {
 
         XCTAssertNil(environment.key)
 
-        environment.setValue(.integer(1), forKey: "key")
+        environment.setValue(.integer(1), forKey: "KEY")
 
         XCTAssertEqual(environment.key, .integer(1))
+        print(environment.values)
     }
 
     func testAddingValueForExistingKeyWithoutForcing() throws {
         var environment = try Environment(values: [
-            "key": .integer(1)
+            "KEY": .integer(1)
         ])
 
         XCTAssertEqual(environment.key, .integer(1))
 
-        environment.setValue(.integer(2), forKey: "key")
+        environment.setValue(.integer(2), forKey: "KEY")
 
         XCTAssertEqual(environment.key, .integer(1))
     }
 
     func testAddingValueForExistingValueWithForcing() throws {
         var environment = try Environment(values: [
-            "key": .integer(1)
+            "KEY": .integer(1)
         ])
 
         XCTAssertEqual(environment.key, .integer(1))
 
-        environment.setValue(.integer(2), forKey: "key", force: true)
+        environment.setValue(.integer(2), forKey: "KEY", force: true)
 
         XCTAssertEqual(environment.key, .integer(2))
     }
@@ -81,7 +82,7 @@ final class EnvironmentTests: XCTestCase {
 
         XCTAssertNil(environment.key)
 
-        let oldValue = environment.removeValue(forKey: "key")
+        let oldValue = environment.removeValue(forKey: "KEY")
 
         XCTAssertNil(oldValue)
     }
@@ -89,12 +90,12 @@ final class EnvironmentTests: XCTestCase {
 
     func testRemovingValue() throws {
         var environment = try Environment(values: [
-            "key": .integer(1)
+            "KEY": .integer(1)
         ])
 
         XCTAssertNotNil(environment.key)
 
-        let oldValue = environment.removeValue(forKey: "key")
+        let oldValue = environment.removeValue(forKey: "KEY")
 
         XCTAssertEqual(oldValue, .integer(1))
         XCTAssertNil(environment.key)

--- a/Tests/Resources/fixture.env
+++ b/Tests/Resources/fixture.env
@@ -1,2 +1,2 @@
-key1=value1
-key2=value2
+API_KEY=some-value
+BUILD_NUMBER=5


### PR DESCRIPTION
### Context

This PR introduces the ability to subscript the environment with dynamic key paths in camel case and have them translate to snake case keys in the `.env` file.

Example:

If your `.env` file looks like 

```
API_KEY=SOME_API_KEY
```

you can now subscript on the environment like

```swift
print(env.apiKey)
```

which will convert the camel case dynamic access to the uppercased snake case format used in the environment file. 