### PR TITLE
Trimming trailing whitespace for values; remove escape double quotes

### DIFF
--- a/Sources/Environment.swift
+++ b/Sources/Environment.swift
@@ -52,7 +52,14 @@ public struct Environment {
             } else if let integerValue = Int(stringValue) {
                 self = .integer(integerValue)
             } else {
-                self = .string(stringValue)
+                // replace escape double quotes
+                var value = stringValue
+                if value[value.startIndex] == "\"" && value[value.index(before: value.endIndex)] == "\"" {
+                    value.remove(at: value.startIndex)
+                    value.remove(at: value.index(before: value.endIndex))
+                    value = value.replacingOccurrences(of: "\\\"", with: "\"")
+                }
+                self = .string(value)
             }
         }
         
@@ -180,12 +187,16 @@ public struct Environment {
         // we loop over all the entries in the file which are already separated by a newline
         var values: OrderedDictionary<String, Value> = .init()
         for line in lines {
+            // ignore comments
+            if line.starts(with: "#") {
+                continue
+            }
             // split by the delimeter
             let substrings = line.split(separator: Self.delimeter)
             // make sure we can grab two and only two string values
             guard
-                let key = substrings.first,
-                let value = substrings.last,
+                let key = substrings.first?.trimmingCharacters(in: .whitespacesAndNewlines),
+                let value = substrings.last?.trimmingCharacters(in: .whitespacesAndNewlines),
                 substrings.count == 2,
                 !key.isEmpty,
                 !value.isEmpty else {

--- a/Sources/Environment.swift
+++ b/Sources/Environment.swift
@@ -53,13 +53,7 @@ public struct Environment {
                 self = .integer(integerValue)
             } else {
                 // replace escape double quotes
-                var value = stringValue
-                if value[value.startIndex] == "\"" && value[value.index(before: value.endIndex)] == "\"" {
-                    value.remove(at: value.startIndex)
-                    value.remove(at: value.index(before: value.endIndex))
-                    value = value.replacingOccurrences(of: "\\\"", with: "\"")
-                }
-                self = .string(value)
+                self = .string(stringValue.trimmingCharacters(in: .init(charactersIn: "\"")).replacingOccurrences(of: "\\\"", with: "\""))
             }
         }
         

--- a/Tests/DotenvTests.swift
+++ b/Tests/DotenvTests.swift
@@ -36,6 +36,9 @@ final class DotenvTests: XCTestCase {
         print(env.values)
         XCTAssertEqual(env.apiKey, .string("some-value"))
         XCTAssertEqual(env.buildNumber, .integer(5))
+        XCTAssertEqual(env.identifier, .string("com.app.example"))
+        XCTAssertEqual(env.mailTemplate, .string("The \"Quoted\" Title"))
+        XCTAssertEqual(env.dbPassphrase, .string("1qaz?#@\"' wsx$"))
         XCTAssertNil(env.nonExistentValue)
     }
     

--- a/Tests/Resources/fixture.env
+++ b/Tests/Resources/fixture.env
@@ -1,2 +1,5 @@
 API_KEY=some-value
 BUILD_NUMBER=5
+IDENTIFIER="com.app.example"
+MAIL_TEMPLATE="The "Quoted" Title"
+DB_PASSPHRASE="1qaz?#@"' wsx$"


### PR DESCRIPTION
Hello I made a small improvement in parsing variables for real world case:

1. Trim trailing whitespace 
2. Remove  escape double quotes in string value
3. Ignore comments in .env file

I also updated `fixture.env` for this changes would be passed in test cases.

Thanks.