### PR TITLE
[Bug] - Gitflow Workflow PR Rename Check

### DIFF
--- a/.github/workflows/gitflow.yml
+++ b/.github/workflows/gitflow.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Install GitHub CLI
         run: brew install gh
       - name: Update pull request title
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           PR_NUMBER="${{ steps.gitflow.outputs.pull_number }}"
           VERSION=$(echo "${{ steps.gitflow.outputs.version }}" | sed 's/^v//')


### PR DESCRIPTION
Forgot to add a check to only rename the PR if it's been triggered from a workflow dispatch event